### PR TITLE
layers/stage3: add stage3 package

### DIFF
--- a/packages/layers/stage3/build.yaml
+++ b/packages/layers/stage3/build.yaml
@@ -1,0 +1,14 @@
+image: "quay.io/mocaccino/extra:latest"
+
+package_dir: /gentoo
+
+prelude:
+- luet upgrade && luet install -y utils/tar utils/curl utils/xz
+- mkdir /gentoo
+
+steps:
+- curl -L http://distfiles.gentoo.org/releases/amd64/autobuilds/current-stage3-amd64/stage3-amd64-systemd-${STAGE_VERSION}.tar.xz | tar Jxp --xattrs --numeric-owner -C /gentoo
+
+env:
+- LUET_YES=true
+- STAGE_VERSION={{ ( index .Values.labels "package.version" ) }}

--- a/packages/layers/stage3/definition.yaml
+++ b/packages/layers/stage3/definition.yaml
@@ -1,0 +1,8 @@
+category: "layers"
+name: "stage3"
+version: "0.20210512"
+labels:
+  package.version: "20210512T214503Z"
+  autobump.strategy: "custom"
+  autobump.hook: "wget -4 -O - http://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3-amd64-systemd.txt --quiet | tail -n 1 | awk 'match($1, /^[0-9a-zA-Z]+/)  { print substr($1, RSTART, RLENGTH) }'"
+  autobump.version_hook: "wget -4 -O - http://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3-amd64-systemd.txt --quiet | tail -n 1 | awk 'match($1, /^[0-9]+/)  { print substr($1, RSTART, RLENGTH) }'"


### PR DESCRIPTION
This adds the =layers/stage3= package which provides with a gentoo stage3 rootfs. Things to check:

- Labels: this is based on gentoo/stage3-amd64 from mocaccinoos/distfiles-collection. I have chosen to preserve the labels in that package (perhaps they are useful for CI)
- Should this be stage3 as proposed or stage3-amd64?